### PR TITLE
Remove duplicate entries of min-lr

### DIFF
--- a/configs/cnndm/attention/multibranch_v2/embed496.yml
+++ b/configs/cnndm/attention/multibranch_v2/embed496.yml
@@ -9,7 +9,6 @@ clip-norm: 0.0
 weight-decay: 0.0
 criterion: label_smoothed_cross_entropy
 label-smoothing: 0.1
-min-lr: 1e-09
 update-freq: 16
 
 keep-last-epochs: 10

--- a/configs/wmt14.en-fr/attention/multibranch_v2/embed200.yml
+++ b/configs/wmt14.en-fr/attention/multibranch_v2/embed200.yml
@@ -9,7 +9,6 @@ clip-norm: 0.0
 weight-decay: 0.0
 criterion: label_smoothed_cross_entropy
 label-smoothing: 0.1
-min-lr: 1e-09
 update-freq: 16
 
 keep-last-epochs: 20

--- a/configs/wmt14.en-fr/attention/multibranch_v2/embed408.yml
+++ b/configs/wmt14.en-fr/attention/multibranch_v2/embed408.yml
@@ -9,7 +9,6 @@ clip-norm: 0.0
 weight-decay: 0.0
 criterion: label_smoothed_cross_entropy
 label-smoothing: 0.1
-min-lr: 1e-09
 update-freq: 16
 
 keep-last-epochs: 20

--- a/configs/wmt14.en-fr/attention/multibranch_v2/embed496.yml
+++ b/configs/wmt14.en-fr/attention/multibranch_v2/embed496.yml
@@ -9,7 +9,6 @@ clip-norm: 0.0
 weight-decay: 0.0
 criterion: label_smoothed_cross_entropy
 label-smoothing: 0.1
-min-lr: 1e-09
 update-freq: 16
 
 keep-last-epochs: 20

--- a/configs/wmt16.en-de/attention/multibranch_v2/embed200.yml
+++ b/configs/wmt16.en-de/attention/multibranch_v2/embed200.yml
@@ -9,7 +9,6 @@ clip-norm: 0.0
 weight-decay: 0.0
 criterion: label_smoothed_cross_entropy
 label-smoothing: 0.1
-min-lr: 1e-09
 update-freq: 16
 
 keep-last-epochs: 20

--- a/configs/wmt16.en-de/attention/multibranch_v2/embed408.yml
+++ b/configs/wmt16.en-de/attention/multibranch_v2/embed408.yml
@@ -9,7 +9,6 @@ clip-norm: 0.0
 weight-decay: 0.0
 criterion: label_smoothed_cross_entropy
 label-smoothing: 0.1
-min-lr: 1e-09
 update-freq: 16
 
 keep-last-epochs: 20

--- a/configs/wmt16.en-de/attention/multibranch_v2/embed496.yml
+++ b/configs/wmt16.en-de/attention/multibranch_v2/embed496.yml
@@ -9,7 +9,6 @@ clip-norm: 0.0
 weight-decay: 0.0
 criterion: label_smoothed_cross_entropy
 label-smoothing: 0.1
-min-lr: 1e-09
 update-freq: 16
 
 keep-last-epochs: 20


### PR DESCRIPTION
Hello,
There are some duplicate entries in the configuration `yml` files. Although keeping these entries won't hurt the running results, it might bring confusion to readers and developers, especially when a developer wants to change a value of such entry and only changed one of the duplicated entries.